### PR TITLE
Add teacher with authtoken

### DIFF
--- a/REF.md
+++ b/REF.md
@@ -1,0 +1,7 @@
+# References
+
+- [request spec - Request specs - RSpec Rails - RSpec - Relish](https://relishapp.com/rspec/rspec-rails/docs/request-specs/request-spec)
+- [RailsのHTTPステータスのシンボル表現まとめ - Hack Your Design!](https://blog.toshimaru.net/rails-http-status-symbols/)
+- [【Rails】RailsでAPIの簡単なトークン認証を実装する - Qiita](https://qiita.com/Yarimizu14/items/c81a8cf1859f954b953e)
+- [Rails5 APIで認証付きのWebAPIを作ってみる - Qiita](https://qiita.com/ochiochi/items/966b884eb17045dfb929)
+- [Build a RESTful JSON API With Rails 5 - Part One ― Scotch](https://scotch.io/tutorials/build-a-restful-json-api-with-rails-5-part-one)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,3 @@
 class ApplicationController < ActionController::API
+  include ExceptionHandler
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,4 @@
 class ApplicationController < ActionController::API
   include ExceptionHandler
+  include Response
 end

--- a/app/controllers/auth_controller.rb
+++ b/app/controllers/auth_controller.rb
@@ -1,4 +1,6 @@
 class AuthController < ApplicationController
   def teacher_login
+    teacher = Teacher.find_by!(username: params[:username], password_digest: params[:password_digest])
+    render json: { token: teacher.token }, status: :ok
   end
 end

--- a/app/controllers/auth_controller.rb
+++ b/app/controllers/auth_controller.rb
@@ -1,0 +1,4 @@
+class AuthController < ApplicationController
+  def teacher_login
+  end
+end

--- a/app/controllers/concerns/exception_handler.rb
+++ b/app/controllers/concerns/exception_handler.rb
@@ -2,6 +2,10 @@ module ExceptionHandler
   extend ActiveSupport::Concern
 
   included do
+    rescue_from ActiveRecord::RecordNotFound do |e|
+      render json: { message: e.message }, status: :bad_request
+    end
+
     rescue_from ActiveRecord::RecordInvalid do |e|
       render json: { message: e.message }, status: :bad_request
     end

--- a/app/controllers/concerns/exception_handler.rb
+++ b/app/controllers/concerns/exception_handler.rb
@@ -1,0 +1,9 @@
+module ExceptionHandler
+  extend ActiveSupport::Concern
+
+  included do
+    rescue_from ActiveRecord::RecordInvalid do |e|
+      render json: { message: e.message }, status: :bad_request
+    end
+  end
+end

--- a/app/controllers/concerns/response.rb
+++ b/app/controllers/concerns/response.rb
@@ -1,0 +1,5 @@
+module Response
+  def json_response(body, status = :ok)
+    render json: body, status: status
+  end
+end

--- a/app/controllers/rooms_controller.rb
+++ b/app/controllers/rooms_controller.rb
@@ -1,5 +1,4 @@
 class RoomsController < ApplicationController
-
   def index
     room = Room.all
     render json: room
@@ -9,7 +8,7 @@ class RoomsController < ApplicationController
     room = Room.find_by(status: 0)
     if room.nil?
       render status: :forbidden
-    elsif
+    else
       room.update(title: params[:title], status: 1)
       render json: room
     end
@@ -22,5 +21,4 @@ class RoomsController < ApplicationController
     room.update(title: 'title', status: 0)
     render json: room
   end
-
 end

--- a/app/controllers/teachers_controller.rb
+++ b/app/controllers/teachers_controller.rb
@@ -1,0 +1,19 @@
+class TeachersController < ApplicationController
+  def show
+  end
+
+  def create
+    teacher = Teacher.create!(create_params)
+    render json: teacher
+  end
+
+  private
+
+  def create_params
+    {
+      fullname: params[:fullname],
+      username: params[:username],
+      password_digest: params[:password_digest]
+    }
+  end
+end

--- a/app/controllers/teachers_controller.rb
+++ b/app/controllers/teachers_controller.rb
@@ -4,7 +4,8 @@ class TeachersController < ApplicationController
 
   # show dashboard...?
   def show
-    render json: @teacher
+    teacher = Teacher.find(params[:id])
+    render json: teacher
   end
 
   def create
@@ -24,8 +25,8 @@ class TeachersController < ApplicationController
 
   def authenticate_token
     authenticate_with_http_token do |token, _|
-      @teacher = Teacher.find_by!(token: token)
-      !@teacher.nil?
+      teacher = Teacher.find_by!(token: token)
+      !teacher.nil?
     end
   end
 

--- a/app/controllers/teachers_controller.rb
+++ b/app/controllers/teachers_controller.rb
@@ -5,12 +5,12 @@ class TeachersController < ApplicationController
   # show dashboard...?
   def show
     teacher = Teacher.find(params[:id])
-    render json: teacher
+    json_response(teacher)
   end
 
   def create
     teacher = Teacher.create!(create_params)
-    render json: teacher
+    json_response(teacher)
   end
 
   private
@@ -31,7 +31,7 @@ class TeachersController < ApplicationController
   end
 
   def render_unauthorized
-    render json: { message: 'Authentication required' }, status: :unauthorized
+    json_response({ message: 'Authorization required' }, :unauthorized)
   end
 
   def authenticate

--- a/app/controllers/teachers_controller.rb
+++ b/app/controllers/teachers_controller.rb
@@ -1,4 +1,7 @@
 class TeachersController < ApplicationController
+  before_action :authenticate, only: %i[show]
+
+  # show dashboard...?
   def show
   end
 

--- a/app/controllers/teachers_controller.rb
+++ b/app/controllers/teachers_controller.rb
@@ -1,8 +1,10 @@
 class TeachersController < ApplicationController
+  include ActionController::HttpAuthentication::Token::ControllerMethods
   before_action :authenticate, only: %i[show]
 
   # show dashboard...?
   def show
+    render json: @teacher
   end
 
   def create
@@ -18,5 +20,20 @@ class TeachersController < ApplicationController
       username: params[:username],
       password_digest: params[:password_digest]
     }
+  end
+
+  def authenticate_token
+    authenticate_with_http_token do |token, _|
+      @teacher = Teacher.find_by!(token: token)
+      !@teacher.nil?
+    end
+  end
+
+  def render_unauthorized
+    render json: { message: 'Authentication required' }, status: :unauthorized
+  end
+
+  def authenticate
+    authenticate_token || render_unauthorized
   end
 end

--- a/app/models/teacher.rb
+++ b/app/models/teacher.rb
@@ -1,0 +1,4 @@
+class Teacher < ApplicationRecord
+  has_secure_token
+  validates_presence_of :fullname, :username, :password_digest
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,4 +4,5 @@ Rails.application.routes.draw do
   end
 
   resources :teachers, only: %i[show create]
+  post 'auth/teacher/login', to: 'auth#teacher_login'
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,4 +2,6 @@ Rails.application.routes.draw do
   resources :rooms, only: [:index, :create, :destroy] do
     resources :questions, only: [:index, :create, :destroy, :update]
   end
+
+  resources :teachers, only: %i[show create]
 end

--- a/db/migrate/20181027124528_create_teachers.rb
+++ b/db/migrate/20181027124528_create_teachers.rb
@@ -1,0 +1,13 @@
+class CreateTeachers < ActiveRecord::Migration[5.2]
+  def change
+    create_table :teachers do |t|
+      t.string :fullname
+      t.string :username
+      t.string :password_digest
+      t.string :token
+
+      t.timestamps
+    end
+    add_index :teachers, :token, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_10_08_091217) do
+ActiveRecord::Schema.define(version: 2018_10_27_124528) do
 
   create_table "questions", force: :cascade do |t|
     t.string "text"
@@ -26,6 +26,16 @@ ActiveRecord::Schema.define(version: 2018_10_08_091217) do
     t.integer "status"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "teachers", force: :cascade do |t|
+    t.string "fullname"
+    t.string "username"
+    t.string "password_digest"
+    t.string "token"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["token"], name: "index_teachers_on_token", unique: true
   end
 
 end

--- a/spec/factories/teachers.rb
+++ b/spec/factories/teachers.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :teacher do
+    fullname { "MyString" }
+    username { "MyString" }
+    password_digest { "MyString" }
+    token { "" }
+  end
+end

--- a/spec/factories/teachers.rb
+++ b/spec/factories/teachers.rb
@@ -1,8 +1,8 @@
 FactoryBot.define do
   factory :teacher do
-    fullname { "MyString" }
-    username { "MyString" }
-    password_digest { "MyString" }
-    token { "" }
+    fullname { Faker::Name.name }
+    username { Faker::Internet.username }
+    password_digest { '5f4dcc3b5aa765d61d8327deb882cf99' } # 'password'
+    token { 'aGVsbG93b3JsZA==' } # Base64.encode64('helloworld').chomp
   end
 end

--- a/spec/models/teacher_spec.rb
+++ b/spec/models/teacher_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe Teacher, type: :model do
+  it { should validate_presence_of(:fullname) }
+  it { should validate_presence_of(:username) }
+  it { should validate_presence_of(:password_digest) }
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -27,6 +27,7 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
 
   config.include FactoryBot::Syntax::Methods
+  config.include RequestSpecHelper, type: :request
 
   config.before(:suite) do
     DatabaseCleaner.clean_with(:truncation)

--- a/spec/requests/auths_spec.rb
+++ b/spec/requests/auths_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+
+RSpec.describe 'Auths', type: :request do
+  describe 'POST /auth/teacher/login' do
+    context 'when request is valid' do
+      let(:teacher) { create(:teacher) }
+      let(:valid_params) do
+        { username: teacher.username, password: teacher.password_digest }
+      end
+      before { post '/auth/teacher/login', params: valid_params }
+
+      it "responses teacher's token" do
+        expect(json['token']).to eq(teacher.token)
+      end
+
+      it 'returns status code 200' do
+        expect(response).to have_http_status(200)
+      end
+    end
+
+    context 'when request is invalid' do
+      before { post '/auth/teacher/login', params: {} }
+      it 'returns status code 400' do
+        expect(response).to have_http_status(400)
+      end
+    end
+  end
+end

--- a/spec/requests/auths_spec.rb
+++ b/spec/requests/auths_spec.rb
@@ -1,16 +1,20 @@
 require 'rails_helper'
 
 RSpec.describe 'Auths', type: :request do
+  let!(:teacher) { create(:teacher) }
+  let(:username) { teacher.username }
+  let(:password) { teacher.password_digest }
+  let(:token) { teacher.token }
+
   describe 'POST /auth/teacher/login' do
     context 'when request is valid' do
-      let(:teacher) { create(:teacher) }
       let(:valid_params) do
-        { username: teacher.username, password: teacher.password_digest }
+        { username: username, password_digest: password }
       end
       before { post '/auth/teacher/login', params: valid_params }
 
       it "responses teacher's token" do
-        expect(json['token']).to eq(teacher.token)
+        expect(json['token']).to eq(token)
       end
 
       it 'returns status code 200' do

--- a/spec/requests/teachers_spec.rb
+++ b/spec/requests/teachers_spec.rb
@@ -29,4 +29,33 @@ RSpec.describe 'Teachers API', type: :request do
       end
     end
   end
+
+  # this is test of authenticate
+  describe 'GET /teachers/:id' do
+    context 'when token is taken' do
+      let!(:teacher) { create(:teacher) }
+      let(:id) { teacher.id }
+      let(:token) { teacher.token }
+      let(:headers) { { 'Authorization' => "Token #{token}" } }
+      before { get "/teachers/#{id}", headers: headers }
+
+      it 'shows teacher detail' do
+        expect(json).to eq(teacher.to_json)
+      end
+
+      it 'returns status code 200' do
+        expect(response).to have_http_status(200)
+      end
+    end
+
+    context 'when token is not taken' do
+      it "shows 'Authentication required' message" do
+        expect(response.body).to match(/Authentication required/)
+      end
+
+      it 'returns status code 401' do
+        expect(response).to have_http_status(401)
+      end
+    end
+  end
 end

--- a/spec/requests/teachers_spec.rb
+++ b/spec/requests/teachers_spec.rb
@@ -49,6 +49,19 @@ RSpec.describe 'Teachers API', type: :request do
       end
     end
 
+    context 'when token is taken but id is invalid' do
+      let(:id) { 0 }
+      before { get "/teachers/#{id}", headers: headers }
+
+      it 'shows error messages' do
+        expect(json['message']).to match(/Couldn't find Teacher/)
+      end
+
+      it 'returns status 400' do
+        expect(response).to have_http_status(400)
+      end
+    end
+
     context 'when token is not taken' do
       before { get "/teachers/#{id}", headers: {} }
 

--- a/spec/requests/teachers_spec.rb
+++ b/spec/requests/teachers_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe 'Teachers API', type: :request do
       before { get "/teachers/#{id}", headers: {} }
 
       it "shows 'Authentication required' message" do
-        expect(json['message']).to match(/Authentication required/)
+        expect(json['message']).to match(/Authorization required/)
       end
 
       it 'returns status code 401' do

--- a/spec/requests/teachers_spec.rb
+++ b/spec/requests/teachers_spec.rb
@@ -32,15 +32,16 @@ RSpec.describe 'Teachers API', type: :request do
 
   # this is test of authenticate
   describe 'GET /teachers/:id' do
+    let!(:teacher) { create(:teacher) }
+    let(:id) { teacher.id }
+    let(:token) { teacher.token }
+    let(:headers) { { 'Authorization' => "Token #{token}" } }
+
     context 'when token is taken' do
-      let!(:teacher) { create(:teacher) }
-      let(:id) { teacher.id }
-      let(:token) { teacher.token }
-      let(:headers) { { 'Authorization' => "Token #{token}" } }
       before { get "/teachers/#{id}", headers: headers }
 
-      it 'shows teacher detail' do
-        expect(json).to eq(teacher.to_json)
+      it 'can show teacher detail' do
+        expect(json['fullname']).to eq(teacher.fullname)
       end
 
       it 'returns status code 200' do
@@ -49,8 +50,10 @@ RSpec.describe 'Teachers API', type: :request do
     end
 
     context 'when token is not taken' do
+      before { get "/teachers/#{id}", headers: {} }
+
       it "shows 'Authentication required' message" do
-        expect(response.body).to match(/Authentication required/)
+        expect(json['message']).to match(/Authentication required/)
       end
 
       it 'returns status code 401' do

--- a/spec/requests/teachers_spec.rb
+++ b/spec/requests/teachers_spec.rb
@@ -10,13 +10,13 @@ RSpec.describe 'Teachers API', type: :request do
         expect(json['fullname']).to eq('John Henecy')
       end
 
-      it 'returns status code 201' do
-        expect(response).to have_http_status(201)
+      it 'returns status code 200' do
+        expect(response).to have_http_status(200)
       end
     end
 
     context 'when request is invalid' do
-      before { post '/techers', params: {} }
+      before { post '/teachers', params: {} }
 
       it 'returns status code 400' do
         expect(response).to have_http_status(400)

--- a/spec/requests/teachers_spec.rb
+++ b/spec/requests/teachers_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+RSpec.describe 'Teachers API', type: :request do
+  describe 'POST /teachers' do
+    context 'when request is valid' do
+      let(:valid_params) { { fullname: 'John Henecy', username: 'john_h', password_digest: '5f4dcc3b5aa765d61d8327deb882cf99' } }
+      before { post '/teachers', params: valid_params }
+
+      it 'creates a new teacher' do
+        expect(json['fullname']).to eq('John Henecy')
+      end
+
+      it 'returns status code 201' do
+        expect(response).to have_http_status(201)
+      end
+    end
+
+    context 'when request is invalid' do
+      before { post '/techers', params: {} }
+
+      it 'returns status code 400' do
+        expect(response).to have_http_status(400)
+      end
+    end
+  end
+end

--- a/spec/requests/teachers_spec.rb
+++ b/spec/requests/teachers_spec.rb
@@ -3,8 +3,14 @@ require 'rails_helper'
 RSpec.describe 'Teachers API', type: :request do
   describe 'POST /teachers' do
     context 'when request is valid' do
-      let(:valid_params) { { fullname: 'John Henecy', username: 'john_h', password_digest: '5f4dcc3b5aa765d61d8327deb882cf99' } }
       before { post '/teachers', params: valid_params }
+      let(:valid_params) do
+        {
+          fullname: 'John Henecy',
+          username: 'john_h',
+          password_digest: '5f4dcc3b5aa765d61d8327deb882cf99'
+        }
+      end
 
       it 'creates a new teacher' do
         expect(json['fullname']).to eq('John Henecy')

--- a/spec/requests/teachers_spec.rb
+++ b/spec/requests/teachers_spec.rb
@@ -24,6 +24,10 @@ RSpec.describe 'Teachers API', type: :request do
     context 'when request is invalid' do
       before { post '/teachers', params: {} }
 
+      it "shows 'Validation failed' message" do
+        expect(json['message']).to match(/Validation failed/)
+      end
+
       it 'returns status code 400' do
         expect(response).to have_http_status(400)
       end

--- a/spec/support/request_spec_helper.rb
+++ b/spec/support/request_spec_helper.rb
@@ -1,0 +1,5 @@
+module RequestSpecHelper
+  def json
+    JSON.parse(response.body)
+  end
+end


### PR DESCRIPTION
`Teacher`モデルと`token`、`Authenticate: Token hogehoge`による認証機構を作りました。
ただし、次のことに留意してください。
- 現在`Teacher`モデルはどことも結合のない状態です
- HTTPの`Authenticate`ヘッダによる認証機構を試すことがメインであったため、最小限のアクションしか定義していません
  - `create` `show`
- `authenticate`が認証の要となっていますが、`teachers#show`にのみ適用してあり、これは大して意味を持ちません
  - この例を参考に、例えば 「`rooms` の一覧取得に認証を必要とする」などのようにべつの場所へ書き加える必要があります
- TDDで行いましたが、そもそも網羅していないケースもあるかと思われますので、見つけ次第ご指摘ください