### PR TITLE
Add CORS header

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ gem 'rubocop', require: false
 gem 'sqlite3', group: %i[development test]
 
 # Use Rack CORS for handling Cross-Origin Resource Sharing (CORS), making cross-origin AJAX possible
-# gem 'rack-cors'
+gem 'rack-cors'
 
 group :development, :test do
   gem 'faker'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -101,6 +101,7 @@ GEM
       pry (~> 0.10)
     puma (3.12.0)
     rack (2.0.5)
+    rack-cors (1.0.2)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rails (5.2.1)
@@ -205,6 +206,7 @@ DEPENDENCIES
   pg
   pry-byebug
   puma (~> 3.11)
+  rack-cors
   rails (~> 5.2.1)
   rails-controller-testing
   rails-erd

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -5,12 +5,11 @@
 
 # Read more: https://github.com/cyu/rack-cors
 
-# Rails.application.config.middleware.insert_before 0, Rack::Cors do
-#   allow do
-#     origins 'example.com'
-#
-#     resource '*',
-#       headers: :any,
-#       methods: [:get, :post, :put, :patch, :delete, :options, :head]
-#   end
-# end
+Rails.application.config.middleware.insert_before 0, Rack::Cors do
+  allow do
+    origins 'smarteach.herokuapp.com', 'localhost:3000'
+    resource '*',
+      headers: :any,
+      methods: [:get, :post, :put, :patch, :delete]
+  end
+end


### PR DESCRIPTION
rack-corsを使ってCORSヘッダーを追加した。

- originは`smarteach.herokuapp.com(:80)`と`localhost:3000`からのみ許可
- すべてのresourceを許可
- methodは`get`, `post`, `put`, `patch`, `delete`を許可

Header周りもすべて許可したつもりだが、認証と併用するのははじめでなので想定通り動作するか心配。