### PR TITLE
Exam open bug

### DIFF
--- a/app/models/exam.rb
+++ b/app/models/exam.rb
@@ -12,7 +12,7 @@ class Exam < ApplicationRecord
   private
 
   def set_default
-    self.room_id = -1
+    self.room_id ||= -1
     self.status ||= 0
   end
 end


### PR DESCRIPTION
## 事象

`POST /v1/exams/:id/open` が正しく機能しない。
具体的にはこのエンドポイントへ`curl`で投げ、レスポンスは正しく`room_id`を生成するが、再度`curl`を用いて`GET /v1/exams/:id`として試験情報へアクセスすると`room_id: -1`となってしまう。
しかも`status: 1`のままなので、DBConsoleから直接updateする以外に修正できなくなってしまう。

## 原因

`Exam`にて宣言していたコールバック`after_initialize`の挙動を把握していなかったために起こったもの。
[ActiveRecord::Callbacks](https://api.rubyonrails.org/classes/ActiveRecord/Callbacks.html)によれば、

> `after_initialize` callback is triggered for each object that is found and instantiated by a finder, with `after_initialize` being triggered after new objects are instantiated as well.

とあり、`Exam.new`のような初期化時(`initialize`)だけでなく`e = Exam.find(:id)`のように**インスタンス化による「初期化」時にもこのコールバックが呼ばれる**ことを表している。

このコールバックは前者にのみ適用されるとして誤った理解をしていたため、このような事が起きた。

## 解決策

修正したコードの通り。